### PR TITLE
chore: support `aws_managed_rules_anti_ddos_rule_set`

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -18,7 +18,7 @@ locals {
 
 module "aws_waf" {
   source  = "cloudposse/waf/aws"
-  version = "1.11.0"
+  version = "1.12.0"
 
   description          = var.description
   default_action       = var.default_action

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -447,6 +447,18 @@ variable "managed_rule_group_statement_rules" {
         }), null)
       })), null)
       managed_rule_group_configs = optional(list(object({
+        aws_managed_rules_anti_ddos_rule_set = optional(object({
+          sensitivity_to_block = optional(string)
+          client_side_action_config = optional(object({
+            challenge = object({
+              usage_of_action = string
+              sensitivity     = optional(string)
+              exempt_uri_regular_expression = optional(list(object({
+                regex_string = string
+              })))
+            })
+          }))
+        }))
         aws_managed_rules_bot_control_rule_set = optional(object({
           inspection_level        = string
           enable_machine_learning = optional(bool, true)

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.2.0"
     }
   }
 }

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0, < 6.0.0"
+      version = ">= 5.0, < 6.3.0"
     }
   }
 }

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0, < 6.3.0"
+      version = ">= 5.0"
     }
   }
 }


### PR DESCRIPTION
## what

- This introduces support for new AWS managed rule group configuration options and updates the AWS provider version constraint. The main changes are grouped below:

---

* Added support for configuring the `aws_managed_rules_anti_ddos_rule_set` in the `managed_rule_group_configs` variable, including options for `sensitivity_to_block` and a nested `client_side_action_config` with challenge settings. (`src/variables.tf`)
* Updated the AWS provider version constraint to allow versions up to but not including 6.3.0, increasing compatibility with newer provider releases. (`src/versions.tf`)

## why

- Previously, a version bump was merged that introduced a feature (`aws_managed_rules_anti_ddos_rule_set`) that is only available in `6.2.0` and later of the provider. This PR updates the version pinning and makes those options accessible in the variable declaration

## references

- [Module PR](https://github.com/cloudposse/terraform-aws-waf/pull/118/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring an AWS Managed Rules Anti‑DDoS rule set within managed rule groups, including sensitivity controls and client-side challenge options with optional URI exemptions.
* **Chores**
  * Raised AWS provider minimum requirement to 6.2.0 and removed the previous upper bound to align with newer provider releases.
  * Bumped the aws_waf module version from 1.11.0 to 1.12.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->