### PR TITLE
add support for aws_managed_rules_acfp_rule_set

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -497,6 +497,49 @@ variable "managed_rule_group_statement_rules" {
             }), null)
           }), null)
         }), null)
+        aws_managed_rules_acfp_rule_set = optional(object({
+          creation_path          = string
+          enable_regex_in_path   = optional(bool)
+          registration_page_path = string
+          request_inspection = optional(object({
+            payload_type = string
+            password_field = optional(object({
+              identifier = string
+            }), null)
+            username_field = optional(object({
+              identifier = string
+            }), null)
+            email_field = optional(object({
+              identifier = string
+            }), null)
+            address_fields = optional(object({
+              identifiers = list(string)
+            }), null)
+            phone_number_fields = optional(object({
+              identifiers = list(string)
+            }), null)
+          }), null)
+          response_inspection = optional(object({
+            body_contains = optional(object({
+              success_strings = list(string)
+              failure_strings = list(string)
+            }), null)
+            header = optional(object({
+              name           = string
+              success_values = list(string)
+              failure_values = list(string)
+            }), null)
+            json = optional(object({
+              identifier     = string
+              success_values = list(string)
+              failure_values = list(string)
+            }), null)
+            status_code = optional(object({
+              success_codes = list(string)
+              failure_codes = list(string)
+            }), null)
+          }), null)
+        }))
       })), null)
     })
     visibility_config = optional(object({


### PR DESCRIPTION
## what
* This introduces support for new AWS managed rule group configuration options (acfp_rule_set)
* Added support for configuring the aws_managed_rules_acfp_rule_set in the managed_rule_group_configs variable, including options for request_inspection, response_inspection, creation_path, registration_page_path, and options for enabling regex (src/variables.tf)

## why
* So users of this component can deploy aws_managed_rules_acfp_rule_set resources

## references
* support added in `terraform-aws-waf` repo here: https://github.com/cloudposse/terraform-aws-waf/pull/119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional configuration to enable AWS Managed Rules ACFP (Account Creation Fraud Prevention) within managed rule groups.
  - Supports defining creation and registration paths, optional regex matching, and detailed request inspection (payload type, credential fields, contact/address fields).
  - Includes response inspection options for body content, headers, JSON fields, and status codes.
  - Enables more granular detection and handling of suspicious account-creation activity without affecting existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->